### PR TITLE
Simplified extension method

### DIFF
--- a/docs/Smartersoft.Identity.Client.Assertion.md
+++ b/docs/Smartersoft.Identity.Client.Assertion.md
@@ -65,7 +65,7 @@ using Smartersoft.Identity.Client.Assertion;
         var app = ConfidentialClientApplicationBuilder
             .Create(clientId)
             .WithAuthority(AzureCloudInstance.AzurePublic, tenantId)
-            .WithKeyVaultCertificate(tenantId, clientId, new Uri(KeyVaultUri), certificateName, tokenCredential)
+            .WithKeyVaultCertificate(new Uri(KeyVaultUri), certificateName, tokenCredential)
             .Build();
 
         // Use the app, just like before
@@ -113,7 +113,7 @@ It can be loaded only once and saved in a config file to reduce the calls to the
         var app = ConfidentialClientApplicationBuilder
             .Create(clientId)
             .WithAuthority(AzureCloudInstance.AzurePublic, tenantId)
-            .WithKeyVaultKey(tenantId, clientId, keyId, kid, tokenCredential)
+            .WithKeyVaultKey(keyId, kid, tokenCredential)
             .Build();
 
         // Use the app, just like before

--- a/src/Smartersoft.Identity.Client.Assertion.Proxy/Controllers/TokenController.cs
+++ b/src/Smartersoft.Identity.Client.Assertion.Proxy/Controllers/TokenController.cs
@@ -47,7 +47,7 @@ namespace Smartersoft.Identity.Client.Assertion.Proxy.Controllers
             var app = ConfidentialClientApplicationBuilder
                 .Create(tokenRequest.ClientId)
                 .WithAuthority(AzureCloudInstance.AzurePublic, tokenRequest.TenantId)
-                .WithKeyVaultKey(tokenRequest.TenantId, tokenRequest.ClientId, tokenRequest.KeyUri, tokenRequest.KeyThumbprint, GetTokenCredential())
+                .WithKeyVaultKey(tokenRequest.KeyUri, tokenRequest.KeyThumbprint, GetTokenCredential())
                 .Build();
 
             var authResult = await app
@@ -86,7 +86,7 @@ namespace Smartersoft.Identity.Client.Assertion.Proxy.Controllers
             var app = ConfidentialClientApplicationBuilder
                 .Create(tokenRequest.ClientId)
                 .WithAuthority(AzureCloudInstance.AzurePublic, tokenRequest.TenantId)
-                .WithKeyVaultCertificate(tokenRequest.TenantId, tokenRequest.ClientId, tokenRequest.KeyVaultUri, tokenRequest.CertificateName, GetTokenCredential())
+                .WithKeyVaultCertificate(tokenRequest.KeyVaultUri, tokenRequest.CertificateName, GetTokenCredential())
                 .Build();
 
             var authResult = await app

--- a/src/Smartersoft.Identity.Client.Assertion/ClientAssertionGenerator.cs
+++ b/src/Smartersoft.Identity.Client.Assertion/ClientAssertionGenerator.cs
@@ -70,7 +70,6 @@ namespace Smartersoft.Identity.Client.Assertion
         /// <param name="lifetime">optional lifetime</param>
         /// <returns></returns>
         [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
-        [Obsolete("Use version with audience")]
         public static IDictionary<string, object> GenerateClaimsForTenant(string tenantId, string clientId, int lifetime = 300)
         {
             string aud = $"https://login.microsoftonline.com/{tenantId}/v2.0";
@@ -116,7 +115,6 @@ namespace Smartersoft.Identity.Client.Assertion
         /// <param name="clientId">Client ID of the calling application</param>
         /// <returns></returns>
         [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
-        [Obsolete("Use version with audience")]
         public static string GetUnsignedToken(string kid, string tenantId, string clientId)
         {
             return GetUnsignedToken(kid, GenerateClaimsForTenant(tenantId, clientId));

--- a/src/Smartersoft.Identity.Client.Assertion/ClientAssertionGenerator.cs
+++ b/src/Smartersoft.Identity.Client.Assertion/ClientAssertionGenerator.cs
@@ -69,6 +69,8 @@ namespace Smartersoft.Identity.Client.Assertion
         /// <param name="clientId">Client ID of the calling application</param>
         /// <param name="lifetime">optional lifetime</param>
         /// <returns></returns>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        [Obsolete("Use version with audience")]
         public static IDictionary<string, object> GenerateClaimsForTenant(string tenantId, string clientId, int lifetime = 300)
         {
             string aud = $"https://login.microsoftonline.com/{tenantId}/v2.0";
@@ -113,6 +115,8 @@ namespace Smartersoft.Identity.Client.Assertion
         /// <param name="tenantId">Tenant ID for which this token will be used</param>
         /// <param name="clientId">Client ID of the calling application</param>
         /// <returns></returns>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        [Obsolete("Use version with audience")]
         public static string GetUnsignedToken(string kid, string tenantId, string clientId)
         {
             return GetUnsignedToken(kid, GenerateClaimsForTenant(tenantId, clientId));
@@ -174,9 +178,27 @@ namespace Smartersoft.Identity.Client.Assertion
         /// <param name="cancellationToken">Use cancellation token if preferred</param>
         /// <remarks>Needs Key => Sign permission, the client assertion is signed in the KeyVault</remarks>
         /// <returns>Signed client assertion</returns>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        [Obsolete("Use version with audience")]
         public static Task<string> GetSignedTokenWithKeyVaultKey(string tenantId, string clientId, Uri keyId, string kid, TokenCredential tokenCredential, CancellationToken cancellationToken = default)
         {
             return GetSignedTokenWithKeyVaultKey(GenerateClaimsForTenant(tenantId, clientId), keyId, kid, tokenCredential, cancellationToken);
+        }
+
+        /// <summary>
+        /// Create a signed client assertion with a Key in the KeyVault
+        /// </summary>
+        /// <param name="keyId">KeyId, Uri of the actual key in the KeyVault</param>
+        /// <param name="kid">The Base64Url encoded hash of the certificate, use GetCertificateInfoFromKeyVault</param>
+        /// <param name="audience">audience to use in the assertion</param>
+        /// <param name="clientId">Client Identifier</param>
+        /// <param name="tokenCredential">Use any TokenCredential (eg. new DefaultTokenCredential())</param>
+        /// <param name="cancellationToken">Use cancellation token if preferred</param>
+        /// <remarks>Needs Key => Sign permission, the client assertion is signed in the KeyVault</remarks>
+        /// <returns>Signed client assertion</returns>
+        public static Task<string> GetSignedTokenWithKeyVaultKey(Uri keyId, string kid, string audience, string clientId, TokenCredential tokenCredential, CancellationToken cancellationToken = default)
+        {
+            return GetSignedTokenWithKeyVaultKey(GenerateClaimsForAudience(audience, clientId), keyId, kid, tokenCredential, cancellationToken);
         }
 
         /// <summary>
@@ -239,9 +261,28 @@ namespace Smartersoft.Identity.Client.Assertion
         /// <param name="cancellationToken">Use cancellation token if preferred</param>
         /// <returns>Signed client assertion</returns>
         /// <remarks>`GetSignedTokenWithKeyVaultKey` is perferred over this method</remarks>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        [Obsolete("Use version with audience")]
         public static Task<string> GetSignedTokenWithKeyVaultCertificate(string tenantId, string clientId, Uri vaultUri, string certificateName, TokenCredential tokenCredential, CancellationToken cancellationToken = default)
         {
             return GetSignedTokenWithKeyVaultCertificate(GenerateClaimsForTenant(tenantId, clientId), vaultUri, certificateName, tokenCredential, cancellationToken);
+        }
+
+        /// <summary>
+        /// Fetches information about the certificate (should be cached!), and then signs a token with the info from the KeyVault
+        /// </summary>
+
+        /// <param name="vaultUri">Uri of the KeyVault</param>
+        /// <param name="certificateName">Name of certificate</param>
+        /// <param name="audience">Assertion audience</param>
+        /// <param name="clientId">Client Identifier</param>
+        /// <param name="tokenCredential">Use any TokenCredential (eg. new DefaultTokenCredential())</param>
+        /// <param name="cancellationToken">Use cancellation token if preferred</param>
+        /// <returns>Signed client assertion</returns>
+        /// <remarks>`GetSignedTokenWithKeyVaultKey` is perferred over this method</remarks>
+        public static Task<string> GetSignedTokenWithKeyVaultCertificate(Uri vaultUri, string certificateName, string audience, string clientId, TokenCredential tokenCredential, CancellationToken cancellationToken = default)
+        {
+            return GetSignedTokenWithKeyVaultCertificate(GenerateClaimsForAudience(audience, clientId), vaultUri, certificateName, tokenCredential, cancellationToken);
         }
     }
 }

--- a/src/Smartersoft.Identity.Client.Assertion/ConfidentialClientApplicationBuilderExtensions.cs
+++ b/src/Smartersoft.Identity.Client.Assertion/ConfidentialClientApplicationBuilderExtensions.cs
@@ -21,6 +21,8 @@ namespace Smartersoft.Identity.Client.Assertion
         /// <param name="clientId">Client Identifier</param>
         /// <param name="vaultUri">Uri of the KeyVault</param>
         /// <param name="certificateName">Name of certificate</param>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        [Obsolete("Replaced by method without Tenant ID and Client ID")]
         public static ConfidentialClientApplicationBuilder WithKeyVaultCertificate(this ConfidentialClientApplicationBuilder applicationBuilder, string tenantId, string clientId, Uri vaultUri, string certificateName)
         {
             return applicationBuilder.WithKeyVaultCertificate(tenantId, clientId, vaultUri, certificateName, new DefaultAzureCredential());
@@ -35,6 +37,8 @@ namespace Smartersoft.Identity.Client.Assertion
         /// <param name="vaultUri">Uri of the KeyVault</param>
         /// <param name="certificateName">Name of certificate</param>
         /// <param name="tokenCredential">Use any TokenCredential (eg. new DefaultTokenCredential())</param>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        [Obsolete("Replaced by method without Tenant ID and Client ID")]
         public static ConfidentialClientApplicationBuilder WithKeyVaultCertificate(this ConfidentialClientApplicationBuilder applicationBuilder, string tenantId, string clientId, Uri vaultUri, string certificateName, TokenCredential tokenCredential)
         {
             return applicationBuilder
@@ -48,10 +52,39 @@ namespace Smartersoft.Identity.Client.Assertion
         /// Add a client assertion, while they key stays in the KeyVault
         /// </summary>
         /// <param name="applicationBuilder">ConfidentialClientApplicationBuilder</param>
+        /// <param name="vaultUri">Uri of the KeyVault</param>
+        /// <param name="certificateName">Name of certificate</param>
+        public static ConfidentialClientApplicationBuilder WithKeyVaultCertificate(this ConfidentialClientApplicationBuilder applicationBuilder, Uri vaultUri, string certificateName)
+        {
+            return applicationBuilder.WithKeyVaultCertificate(vaultUri, certificateName, new DefaultAzureCredential());
+        }
+
+        /// <summary>
+        /// Add a client assertion, while they key stays in the KeyVault
+        /// </summary>
+        /// <param name="applicationBuilder">ConfidentialClientApplicationBuilder</param>
+        /// <param name="vaultUri">Uri of the KeyVault</param>
+        /// <param name="certificateName">Name of certificate</param>
+        /// <param name="tokenCredential">Use any TokenCredential (eg. new DefaultTokenCredential())</param>
+        public static ConfidentialClientApplicationBuilder WithKeyVaultCertificate(this ConfidentialClientApplicationBuilder applicationBuilder, Uri vaultUri, string certificateName, TokenCredential tokenCredential)
+        {
+            return applicationBuilder
+                //.WithAuthority(AzureCloudInstance.AzurePublic, tenantId)
+                .WithClientAssertion((AssertionRequestOptions options) =>
+                    ClientAssertionGenerator.GetSignedTokenWithKeyVaultCertificate(vaultUri, certificateName, options.TokenEndpoint, options.ClientID, tokenCredential, cancellationToken: options.CancellationToken)
+                );
+        }
+
+        /// <summary>
+        /// Add a client assertion, while they key stays in the KeyVault
+        /// </summary>
+        /// <param name="applicationBuilder">ConfidentialClientApplicationBuilder</param>
         /// <param name="tenantId">Tenant ID for which you want to use this token</param>
         /// <param name="clientId">Client Identifier</param>
         /// <param name="keyVaultKeyId">KeyId, Uri of the actual key in the KeyVault</param>
         /// <param name="kid">The Base64Url encoded hash of the certificate, use GetCertificateInfoFromKeyVault</param>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        [Obsolete("Replaced by method without Tenant ID and Client ID")]
         public static ConfidentialClientApplicationBuilder WithKeyVaultKey(this ConfidentialClientApplicationBuilder applicationBuilder, string tenantId, string clientId, Uri keyVaultKeyId, string kid)
         {
             return applicationBuilder.WithKeyVaultKey(tenantId, clientId, keyVaultKeyId, kid, new DefaultAzureCredential());
@@ -67,12 +100,41 @@ namespace Smartersoft.Identity.Client.Assertion
         /// <param name="keyVaultKeyId">KeyId, Uri of the actual key in the KeyVault</param>
         /// <param name="kid">The Base64Url encoded hash of the certificate, use GetCertificateInfoFromKeyVault</param>
         /// <param name="tokenCredential">Use any TokenCredential (eg. new DefaultTokenCredential())</param>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        [Obsolete("Replaced by method without Tenant ID and Client ID")]
         public static ConfidentialClientApplicationBuilder WithKeyVaultKey(this ConfidentialClientApplicationBuilder applicationBuilder, string tenantId, string clientId, Uri keyVaultKeyId, string kid, TokenCredential tokenCredential)
         {
             return applicationBuilder
                 //.WithAuthority(AzureCloudInstance.AzurePublic, tenantId)
                 .WithClientAssertion((CancellationToken cancellationToken) =>
                     ClientAssertionGenerator.GetSignedTokenWithKeyVaultKey(tenantId, clientId, keyVaultKeyId, kid, tokenCredential, cancellationToken: cancellationToken)
+                );
+        }
+
+        /// <summary>
+        /// Add a client assertion, while they key stays in the KeyVault
+        /// </summary>
+        /// <param name="applicationBuilder">ConfidentialClientApplicationBuilder</param>
+        /// <param name="keyVaultKeyId">KeyId, Uri of the actual key in the KeyVault</param>
+        /// <param name="kid">The Base64Url encoded hash of the certificate, use GetCertificateInfoFromKeyVault</param>
+        public static ConfidentialClientApplicationBuilder WithKeyVaultKey(this ConfidentialClientApplicationBuilder applicationBuilder, Uri keyVaultKeyId, string kid)
+        {
+            return applicationBuilder.WithKeyVaultKey(keyVaultKeyId, kid, new DefaultAzureCredential());
+        }
+
+        /// <summary>
+        /// Add a client assertion, while they key stays in the KeyVault
+        /// </summary>
+        /// <param name="applicationBuilder">ConfidentialClientApplicationBuilder</param>
+        /// <param name="keyVaultKeyId">KeyId, Uri of the actual key in the KeyVault</param>
+        /// <param name="kid">The Base64Url encoded hash of the certificate, use GetCertificateInfoFromKeyVault</param>
+        /// <param name="tokenCredential">Use any TokenCredential (eg. new DefaultTokenCredential())</param>
+        public static ConfidentialClientApplicationBuilder WithKeyVaultKey(this ConfidentialClientApplicationBuilder applicationBuilder, Uri keyVaultKeyId, string kid, TokenCredential tokenCredential)
+        {
+            return applicationBuilder
+                //.WithAuthority(AzureCloudInstance.AzurePublic, tenantId)
+                .WithClientAssertion((AssertionRequestOptions options) =>
+                    ClientAssertionGenerator.GetSignedTokenWithKeyVaultKey(keyVaultKeyId, kid, options.TokenEndpoint, options.ClientID, tokenCredential, cancellationToken: options.CancellationToken)
                 );
         }
     }

--- a/src/Smartersoft.Identity.Client.Assertion/Smartersoft.Identity.Client.Assertion.csproj
+++ b/src/Smartersoft.Identity.Client.Assertion/Smartersoft.Identity.Client.Assertion.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Azure.Identity" Version="1.6.0" />
     <PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.3.0" />
     <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.3.0" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.43.1" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.45.0" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\docs\Smartersoft.Identity.Client.Assertion.md" Pack="true" PackagePath="\README.md" />


### PR DESCRIPTION
Because of this PR (by @svrooij) https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/3376 we no longer need to set the Tenant ID and Client ID twice since they are provided by the ClientBuilder when calling to generate the assertion.