### PR TITLE
Dotnet 7

### DIFF
--- a/.github/workflows/build-solution.yml
+++ b/.github/workflows/build-solution.yml
@@ -23,7 +23,7 @@ jobs:
 
     - uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '6.0.x'
+        dotnet-version: '7.x'
 
     - name: Restore dependencies
       run: dotnet restore $SOLUTION

--- a/.github/workflows/release-extensions.yml
+++ b/.github/workflows/release-extensions.yml
@@ -38,7 +38,7 @@ jobs:
 
     - uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '6.0.x'
+        dotnet-version: '7.x'
 
     - name: Restore dependencies
       run: dotnet restore $SOLUTION

--- a/.github/workflows/release-proxy.yml
+++ b/.github/workflows/release-proxy.yml
@@ -39,7 +39,7 @@ jobs:
 
     - uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '6.0.x'
+        dotnet-version: '7.x'
 
     - name: Restore dependencies
       run: dotnet restore $SOLUTION

--- a/.pipeline.yml
+++ b/.pipeline.yml
@@ -30,7 +30,7 @@ steps:
 - task: UseDotNet@2
   inputs:
     packageType: 'sdk'
-    version: '6.x'
+    version: '7.x'
 
 - task: DotNetCoreCLI@2
   displayName: Restore dependencies library

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This library is created by [Smartersoft B.V.](https://smartersoft.nl) and [licen
 [![GitHub issues][badge_issues]][link_issues]
 [![GitHub Sponsors][badge_sponsor]][link_sponsor]
 
-[Smartersoft.Identity.Client.Assertion.Proxy](docs/Smartersoft.Identity.Client.Assertion.Proxy.md) is a small api you can run on your local machine to use certificates stored in the KeyVault to secure your client credentials during development.
+[Smartersoft.Identity.Client.Assertion.Proxy](docs/Smartersoft.Identity.Client.Assertion.Proxy.md) is a small api you can run on your local machine to use certificates stored in the KeyVault (or local certificate store) to secure your client credentials during development.
 
 ## License
 

--- a/Smartersoft.Identity.Client.Assertion.sln
+++ b/Smartersoft.Identity.Client.Assertion.sln
@@ -8,7 +8,10 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Deploy", "Deploy", "{1CA888C2-89BC-4DA4-A9FB-885673089C2A}"
 	ProjectSection(SolutionItems) = preProject
 		.pipeline.yml = .pipeline.yml
+		.github\workflows\build-solution.yml = .github\workflows\build-solution.yml
 		GitVersion.yml = GitVersion.yml
+		.github\workflows\release-extensions.yml = .github\workflows\release-extensions.yml
+		.github\workflows\release-proxy.yml = .github\workflows\release-proxy.yml
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Smartersoft.Identity.Client.Assertion.Proxy", "src\Smartersoft.Identity.Client.Assertion.Proxy\Smartersoft.Identity.Client.Assertion.Proxy.csproj", "{75387092-CA7A-413F-AADC-4033C44CEACA}"

--- a/docs/Smartersoft.Identity.Client.Assertion.md
+++ b/docs/Smartersoft.Identity.Client.Assertion.md
@@ -151,3 +151,7 @@ Off course this solution still needs a secure way to access the Key Vault, like 
 ## License
 
 These packages are [licensed](https://github.com/Smartersoft/identity-client-assertion/blob/main/LICENSE.txt) under `GPL-3.0`, if you wish to use this software under a different license. Or you feel that this really helped in your commercial application and wish to support us? You can [get in touch](https://smartersoft.nl/#contact) and we can talk terms. We are available as consultants.
+
+## Open-source
+
+This package is open-source for a reason. It's developed by [Stephan van Rooij](https://svrooij.io/), I'm a talented software architect, but people make mistakes. Always check out what's doing and make sure it doesn't do anything strange with the tokens. And that I didn't make any rudimentary mistakes. 

--- a/src/Smartersoft.Identity.Client.Assertion.Proxy/ConsoleStyle.cs
+++ b/src/Smartersoft.Identity.Client.Assertion.Proxy/ConsoleStyle.cs
@@ -1,7 +1,7 @@
 ﻿
 using System.Reflection;
 
-public static class ConsoleStyle
+internal static class ConsoleStyle
 {
     private const string Header = @"
  _______  _______        _                        _______  _______  _______                   

--- a/src/Smartersoft.Identity.Client.Assertion.Proxy/Smartersoft.Identity.Client.Assertion.Proxy.csproj
+++ b/src/Smartersoft.Identity.Client.Assertion.Proxy/Smartersoft.Identity.Client.Assertion.Proxy.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <Authors>Smartersoft B.V.,Stephan van Rooij</Authors>
@@ -27,7 +27,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentValidation.AspNetCore" Version="10.4.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Smartersoft.Identity.Client.Assertion\Smartersoft.Identity.Client.Assertion.csproj" />

--- a/src/Smartersoft.Identity.Client.Assertion/ConfidentialClientApplicationBuilderExtensions.cs
+++ b/src/Smartersoft.Identity.Client.Assertion/ConfidentialClientApplicationBuilderExtensions.cs
@@ -137,5 +137,29 @@ namespace Smartersoft.Identity.Client.Assertion
                     ClientAssertionGenerator.GetSignedTokenWithKeyVaultKey(keyVaultKeyId, kid, options.TokenEndpoint, options.ClientID, tokenCredential, cancellationToken: options.CancellationToken)
                 );
         }
+
+        /// <summary>
+        /// Add a client assertion using a Managed Identity, configured as Federated Credential.
+        /// </summary>
+        /// <param name="applicationBuilder">ConfidentialClientApplicationBuilder</param>
+        /// <param name="managedIdentityScope">The scope used for the federated credential api</param>
+        /// <remarks>Check this post for more details: https://svrooij.io/2022/06/21/managed-identity-multi-tenant-app/</remarks>
+        public static ConfidentialClientApplicationBuilder WithManagedIdentity(this ConfidentialClientApplicationBuilder applicationBuilder, string managedIdentityScope) => applicationBuilder.WithManagedIdentity(managedIdentityScope, new ManagedIdentityCredential());
+
+        /// <summary>
+        /// Add a client assertion using a Managed Identity, configured as Federated Credential.
+        /// </summary>
+        /// <param name="applicationBuilder">ConfidentialClientApplicationBuilder</param>
+        /// <param name="managedIdentityScope">The scope used for the federated credential api, eg. `{app-uri}/.default`</param>
+        /// <param name="managedIdentityCredential">Use any TokenCredential (eg. new ManagedIdentityCredential())</param>
+        /// <remarks>Check this post for more details: https://svrooij.io/2022/06/21/managed-identity-multi-tenant-app/</remarks>
+        public static ConfidentialClientApplicationBuilder WithManagedIdentity(this ConfidentialClientApplicationBuilder applicationBuilder, string managedIdentityScope, TokenCredential managedIdentityCredential)
+        {
+            return applicationBuilder.WithClientAssertion(async (AssertionRequestOptions options) =>
+            {
+                var tokenResult = await managedIdentityCredential.GetTokenAsync(new TokenRequestContext(new[] { managedIdentityScope }), options.CancellationToken);
+                return tokenResult.Token;
+            });
+        }
     }
 }

--- a/src/Smartersoft.Identity.Client.Assertion/ConfidentialClientApplicationBuilderExtensions.cs
+++ b/src/Smartersoft.Identity.Client.Assertion/ConfidentialClientApplicationBuilderExtensions.cs
@@ -2,8 +2,6 @@
 using Azure.Identity;
 using Microsoft.Identity.Client;
 using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading;
 
 namespace Smartersoft.Identity.Client.Assertion
@@ -90,7 +88,6 @@ namespace Smartersoft.Identity.Client.Assertion
             return applicationBuilder.WithKeyVaultKey(tenantId, clientId, keyVaultKeyId, kid, new DefaultAzureCredential());
         }
 
-
         /// <summary>
         /// Add a client assertion, while they key stays in the KeyVault
         /// </summary>
@@ -143,7 +140,8 @@ namespace Smartersoft.Identity.Client.Assertion
         /// </summary>
         /// <param name="applicationBuilder">ConfidentialClientApplicationBuilder</param>
         /// <param name="managedIdentityScope">The scope used for the federated credential api</param>
-        /// <remarks>Check this post for more details: https://svrooij.io/2022/06/21/managed-identity-multi-tenant-app/</remarks>
+        /// <see href="https://svrooij.io/2022/06/21/managed-identity-multi-tenant-app/">Blog post</see>
+        /// <remarks>This is experimental, since federated credentials are still in preview.</remarks>
         public static ConfidentialClientApplicationBuilder WithManagedIdentity(this ConfidentialClientApplicationBuilder applicationBuilder, string managedIdentityScope) => applicationBuilder.WithManagedIdentity(managedIdentityScope, new ManagedIdentityCredential());
 
         /// <summary>
@@ -152,7 +150,8 @@ namespace Smartersoft.Identity.Client.Assertion
         /// <param name="applicationBuilder">ConfidentialClientApplicationBuilder</param>
         /// <param name="managedIdentityScope">The scope used for the federated credential api, eg. `{app-uri}/.default`</param>
         /// <param name="managedIdentityCredential">Use any TokenCredential (eg. new ManagedIdentityCredential())</param>
-        /// <remarks>Check this post for more details: https://svrooij.io/2022/06/21/managed-identity-multi-tenant-app/</remarks>
+        /// <see href="https://svrooij.io/2022/06/21/managed-identity-multi-tenant-app/">Blog post</see>
+        /// <remarks>This is experimental, since federated credentials are still in preview.</remarks>
         public static ConfidentialClientApplicationBuilder WithManagedIdentity(this ConfidentialClientApplicationBuilder applicationBuilder, string managedIdentityScope, TokenCredential managedIdentityCredential)
         {
             return applicationBuilder.WithClientAssertion(async (AssertionRequestOptions options) =>

--- a/src/Smartersoft.Identity.Client.Assertion/Smartersoft.Identity.Client.Assertion.csproj
+++ b/src/Smartersoft.Identity.Client.Assertion/Smartersoft.Identity.Client.Assertion.csproj
@@ -24,10 +24,10 @@
     <NoWarn>1701;1702;CS8616;CS1591;CS8604</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.6.0" />
-    <PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.3.0" />
-    <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.3.0" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.45.0" />
+    <PackageReference Include="Azure.Identity" Version="1.8.0" />
+    <PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.4.0" />
+    <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.4.0" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.48.1" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\docs\Smartersoft.Identity.Client.Assertion.md" Pack="true" PackagePath="\README.md" />


### PR DESCRIPTION
- Package updates
- Moved proxy to .net 7
- Support for using managed identity as client credentials